### PR TITLE
Hotfix [SWP-2431] MIS: Loading + no results states on data grids

### DIFF
--- a/dist/jquery.bootgrid.js
+++ b/dist/jquery.bootgrid.js
@@ -960,10 +960,10 @@ function renderSearchField()
             {
                 e.stopPropagation();
                 var newValue = $(this).val();
-                if (currentValue !== newValue)
+                if (currentValue !== newValue || (e.which === 13 && newValue !== ""))
                 {
                     currentValue = newValue;
-                    if (newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
+                    if (e.which === 13 || newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
                     {
                         window.clearTimeout(timer);
                         timer = window.setTimeout(function ()

--- a/dist/jquery.bootgrid.js
+++ b/dist/jquery.bootgrid.js
@@ -1,5 +1,5 @@
 /*! 
- * jQuery Bootgrid v1.1.4 - 01/12/2021
+ * jQuery Bootgrid v1.1.4 - 06/01/2021
  * Copyright (c) 2021 Rafael Staib (http://www.jquery-bootgrid.com)
  * Licensed under MIT http://www.opensource.org/licenses/MIT
  */
@@ -963,11 +963,14 @@ function renderSearchField()
                 if (currentValue !== newValue)
                 {
                     currentValue = newValue;
-                    window.clearTimeout(timer);
-                    timer = window.setTimeout(function ()
+                    if (newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
                     {
-                        that.search(newValue);
-                    }, 250);
+                        window.clearTimeout(timer);
+                        timer = window.setTimeout(function ()
+                        {
+                            that.search(newValue);
+                        }, that.options.searchSettings.delay);
+                    }
                 }
             });
 
@@ -1330,6 +1333,35 @@ Grid.defaults = {
     ajax: false, // todo: find a better name for this property to differentiate between client-side and server-side data
     method: "GET",  //todo: user control over url- /rest/like/paths instead of query string for instance.
                     //      'url' and 'request' passed together to requestHandler perhaps.
+
+    /**
+     * General search settings to configure the search field behaviour.
+     *
+     * @property searchSettings
+     * @type Object
+     * @for defaults
+     **/
+    searchSettings: {
+        /**
+         * The time in milliseconds to wait before search gets executed.
+         *
+         * @property delay
+         * @type Number
+         * @default 250
+         * @for searchSettings
+         **/
+        delay: 250,
+
+        /**
+         * The characters to type before the search gets executed.
+         *
+         * @property characters
+         * @type Number
+         * @default 1
+         * @for searchSettings
+         **/
+        characters: 1
+    },
 
     /**
      * Enriches the request object with additional properties. Either a `PlainObject` or a `Function`

--- a/src/internal.js
+++ b/src/internal.js
@@ -953,11 +953,14 @@ function renderSearchField()
                 if (currentValue !== newValue)
                 {
                     currentValue = newValue;
-                    window.clearTimeout(timer);
-                    timer = window.setTimeout(function ()
+                    if (newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
                     {
-                        that.search(newValue);
-                    }, 250);
+                        window.clearTimeout(timer);
+                        timer = window.setTimeout(function ()
+                        {
+                            that.search(newValue);
+                        }, that.options.searchSettings.delay);
+                    }
                 }
             });
 

--- a/src/internal.js
+++ b/src/internal.js
@@ -950,10 +950,10 @@ function renderSearchField()
             {
                 e.stopPropagation();
                 var newValue = $(this).val();
-                if (currentValue !== newValue)
+                if (currentValue !== newValue || (e.which === 13 && newValue !== ""))
                 {
                     currentValue = newValue;
-                    if (newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
+                    if (e.which === 13 || newValue.length === 0 || newValue.length >= that.options.searchSettings.characters)
                     {
                         window.clearTimeout(timer);
                         timer = window.setTimeout(function ()

--- a/src/public.js
+++ b/src/public.js
@@ -118,6 +118,35 @@ Grid.defaults = {
                     //      'url' and 'request' passed together to requestHandler perhaps.
 
     /**
+     * General search settings to configure the search field behaviour.
+     *
+     * @property searchSettings
+     * @type Object
+     * @for defaults
+     **/
+    searchSettings: {
+        /**
+         * The time in milliseconds to wait before search gets executed.
+         *
+         * @property delay
+         * @type Number
+         * @default 250
+         * @for searchSettings
+         **/
+        delay: 250,
+
+        /**
+         * The characters to type before the search gets executed.
+         *
+         * @property characters
+         * @type Number
+         * @default 1
+         * @for searchSettings
+         **/
+        characters: 1
+    },
+
+    /**
      * Enriches the request object with additional properties. Either a `PlainObject` or a `Function`
      * that returns a `PlainObject` can be passed. Default value is `{}`.
      *


### PR DESCRIPTION
Introducing search settings from `1.2.0` upstream as we're now stuck with that modified version of `1.1.4`.

See:
- http://www.jquery-bootgrid.com/Documentation#searchsettings
- https://github.com/rstaib/jquery-bootgrid/compare/1.1.4...1.2.0